### PR TITLE
squashWith 2

### DIFF
--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/MomentState.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/MomentState.kt
@@ -2,11 +2,7 @@ package io.github.oxidefrp.core.shared
 
 import io.github.oxidefrp.core.Moment
 import io.github.oxidefrp.core.Signal
-import io.github.oxidefrp.core.Time
 import io.github.oxidefrp.core.pullOf
-import io.github.oxidefrp.core.shared.State
-import io.github.oxidefrp.core.shared.StateSchedulerLayer
-import io.github.oxidefrp.core.shared.StateStructure
 
 abstract class MomentState<S, out A> {
     companion object {
@@ -138,9 +134,6 @@ abstract class MomentState<S, out A> {
     }
 
     abstract fun enterDirectly(oldState: S): Moment<Pair<S, A>>
-
-    fun pullEnterDirectly(t: Time, oldState: S): Pair<S, A> =
-        enterDirectly(oldState).pullDirectly(t)
 
     fun <B> pullEnterOf(
         transform: (A) -> MomentState<S, B>,

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/utils.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/utils.kt
@@ -1,0 +1,6 @@
+package io.github.oxidefrp.core
+
+import io.github.oxidefrp.core.shared.MomentState
+
+fun <S, A> MomentState<S, A>.pullEnterDirectly(t: Time, oldState: S): Pair<S, A> =
+    enterDirectly(oldState).pullDirectly(t)

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/shared/EventStreamSharedUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/shared/EventStreamSharedUnitTests.kt
@@ -20,7 +20,7 @@ import io.github.oxidefrp.core.test_framework.shared.withTail
 import io.github.oxidefrp.core.test_framework.testSystem
 import kotlin.test.Test
 
-class EventStreamOperatorsUnitTests {
+class EventStreamSharedUnitTests {
     object Never {
         @Test
         fun test() = testSystem {

--- a/operational/core/src/main/kotlin/io/github/oxidefrp/core/EventStream.kt
+++ b/operational/core/src/main/kotlin/io/github/oxidefrp/core/EventStream.kt
@@ -13,6 +13,7 @@ import io.github.oxidefrp.core.impl.event_stream.ProbeEventStreamVertex
 import io.github.oxidefrp.core.impl.event_stream.PullEventStreamVertex
 import io.github.oxidefrp.core.impl.event_stream.SourceEventStreamVertex
 import io.github.oxidefrp.core.impl.event_stream.SparkMomentVertex
+import io.github.oxidefrp.core.impl.event_stream.SquashWithEventStreamVertex
 import io.github.oxidefrp.core.impl.event_stream.SubscriptionVertex
 import io.github.oxidefrp.core.impl.event_stream.TransactionSubscription
 import io.github.oxidefrp.core.impl.getOrNull
@@ -210,6 +211,23 @@ fun <A, R> EventStream<A>.accum(
         EventStream.Loop1(
             streamA = steps,
             result = accumulator,
+        )
+    }
+}
+
+fun <A, B, C> EventStream<A>.squashWith(
+    other: EventStream<B>,
+    ifFirst: (A) -> C,
+    ifSecond: (B) -> C,
+    ifBoth: (A, B) -> C,
+): EventStream<C> = object : EventStream<C>() {
+    override val vertex: EventStreamVertex<C> by lazy {
+        SquashWithEventStreamVertex(
+            source1 = this@squashWith.vertex,
+            source2 = other.vertex,
+            ifFirst = ifFirst,
+            ifSecond = ifSecond,
+            ifBoth = ifBoth,
         )
     }
 }

--- a/operational/core/src/main/kotlin/io/github/oxidefrp/core/impl/event_stream/SquashWithEventStreamVertex.kt
+++ b/operational/core/src/main/kotlin/io/github/oxidefrp/core/impl/event_stream/SquashWithEventStreamVertex.kt
@@ -1,0 +1,29 @@
+package io.github.oxidefrp.core.impl.event_stream
+
+import io.github.oxidefrp.core.impl.Option
+import io.github.oxidefrp.core.impl.Transaction
+import io.github.oxidefrp.core.impl.orElse
+
+internal class SquashWithEventStreamVertex<A, B, C>(
+    private val source1: EventStreamVertex<A>,
+    private val source2: EventStreamVertex<B>,
+    private val ifFirst: (A) -> C,
+    private val ifSecond: (B) -> C,
+    private val ifBoth: (A, B) -> C,
+) : ObservingEventStreamVertex<C>() {
+    override fun observe(transaction: Transaction): TransactionSubscription {
+        val subscription1 = source1.registerDependent(transaction = transaction, dependent = this)
+        val subscription2 = source2.registerDependent(transaction = transaction, dependent = this)
+        return subscription1 + subscription2
+    }
+
+    override fun pullCurrentOccurrenceUncached(transaction: Transaction): Option<C> {
+        val occurrence1 = source1.pullCurrentOccurrence(transaction = transaction)
+        val occurrence2 = source2.pullCurrentOccurrence(transaction = transaction)
+
+        return Option
+            .map2(occurrence1, occurrence2, ifBoth)
+            .orElse { occurrence1.map(ifFirst) }
+            .orElse { occurrence2.map(ifSecond) }
+    }
+}


### PR DESCRIPTION
- Move `MomentState` & friends to the new shared sub-package
- Rename `EventStreamOperatorsUnitTests` to `EventStreamSharedUnitTests`
- Implement `squashWith` operationally
- Add a `squashWith` test
