### PR TITLE
share utils 1

### DIFF
--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/Cell.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/Cell.kt
@@ -2,13 +2,10 @@ package io.github.oxidefrp.core
 
 import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.State
-import io.github.oxidefrp.core.shared.StateSchedulerLayer
 import io.github.oxidefrp.core.shared.StateStructure
 import io.github.oxidefrp.core.shared.construct
 import io.github.oxidefrp.core.shared.enter
-import io.github.oxidefrp.core.shared.pull
 import io.github.oxidefrp.core.shared.pullEnter
-import io.github.oxidefrp.core.shared.unzip2
 
 data class ValueChange<out A>(
     val oldValue: A,
@@ -249,10 +246,6 @@ abstract class Cell<out A> {
     fun <S, B> enterOf(
         transform: (A) -> State<S, B>,
     ): StateStructure<S, Cell<B>> = enter(map(transform))
-
-    fun <B> pullOf(
-        transform: (A) -> Moment<B>,
-    ): Moment<Cell<B>> = pull(map(transform))
 
     fun <S, B> pullEnterOf(
         transform: (A) -> MomentState<S, B>,

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/EventStream.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/EventStream.kt
@@ -4,6 +4,7 @@ import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.State
 import io.github.oxidefrp.core.shared.StateScheduler
 import io.github.oxidefrp.core.shared.StateSchedulerLayer
+import io.github.oxidefrp.core.shared.pullEnter
 
 abstract class EventStream<out A> {
     data class Loop1<A, R>(
@@ -75,25 +76,6 @@ abstract class EventStream<out A> {
         fun <S> enterUnit(
             stream: EventStream<State<S, Unit>>,
         ): StateScheduler<S, Unit> = pullEnter(stream.map { it.asMomentState() }).map { }
-
-        fun <S, A> pullEnter(
-            stream: EventStream<MomentState<S, A>>,
-        ): StateScheduler<S, EventStream<A>> = object : StateScheduler<S, EventStream<A>>() {
-            override fun scheduleDirectly(
-                stateSignal: Signal<S>,
-            ) = object : State<StateSchedulerLayer<S>, EventStream<A>>() {
-                override fun enterDirectly(
-                    oldState: StateSchedulerLayer<S>,
-                ): Pair<StateSchedulerLayer<S>, EventStream<A>> {
-                    val previousSchedulerLayer = oldState
-
-                    return previousSchedulerLayer.squashWith(
-                        stateSignal = stateSignal,
-                        stream = stream
-                    )
-                }
-            }
-        }
 
         fun <A, R> pullLooped1(
             f: (streamA: EventStream<A>) -> Moment<EventStream.Loop1<A, R>>,

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/EventStream.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/EventStream.kt
@@ -1,9 +1,8 @@
 package io.github.oxidefrp.core
 
-import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.State
 import io.github.oxidefrp.core.shared.StateScheduler
-import io.github.oxidefrp.core.shared.StateSchedulerLayer
+import io.github.oxidefrp.core.shared.enter
 import io.github.oxidefrp.core.shared.pullEnter
 
 abstract class EventStream<out A> {
@@ -68,11 +67,6 @@ abstract class EventStream<out A> {
                 }
             }
         }
-
-        fun <S, A> enter(
-            stream: EventStream<State<S, A>>,
-        ): StateScheduler<S, EventStream<A>> = pullEnter(stream.map { it.asMomentState() })
-
         fun <S> enterUnit(
             stream: EventStream<State<S, Unit>>,
         ): StateScheduler<S, Unit> = pullEnter(stream.map { it.asMomentState() }).map { }

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/MomentState.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/MomentState.kt
@@ -2,7 +2,6 @@ package io.github.oxidefrp.core.shared
 
 import io.github.oxidefrp.core.Moment
 import io.github.oxidefrp.core.Signal
-import io.github.oxidefrp.core.pullOf
 
 abstract class MomentState<S, out A> {
     companion object {

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/StateScheduler.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/StateScheduler.kt
@@ -5,7 +5,7 @@ import io.github.oxidefrp.core.EventStream
 import io.github.oxidefrp.core.Moment
 import io.github.oxidefrp.core.Signal
 import io.github.oxidefrp.core.mapNotNull
-import io.github.oxidefrp.core.pullOf
+import io.github.oxidefrp.core.shared.pullOf
 import io.github.oxidefrp.core.squashWith
 
 data class StateSchedulerLayer<S>(

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/StateStructure.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/StateStructure.kt
@@ -5,7 +5,7 @@ import io.github.oxidefrp.core.EventStream
 import io.github.oxidefrp.core.Moment
 import io.github.oxidefrp.core.Signal
 import io.github.oxidefrp.core.hold
-import io.github.oxidefrp.core.pullOf
+import io.github.oxidefrp.core.shared.pullOf
 
 abstract class StateStructure<S, out A> {
     companion object {

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/cellUtils.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/cellUtils.kt
@@ -5,7 +5,7 @@ import io.github.oxidefrp.core.EventStream
 import io.github.oxidefrp.core.Moment
 import io.github.oxidefrp.core.Signal
 import io.github.oxidefrp.core.hold
-import io.github.oxidefrp.core.pullOf
+import io.github.oxidefrp.core.shared.pullOf
 
 fun <A> Cell.Companion.pull(
     cell: Cell<Moment<A>>,
@@ -52,6 +52,10 @@ fun <A, B> Cell.Companion.unzip2(
     cell.map { it.first },
     cell.map { it.second },
 )
+
+fun <A, B> Cell<A>.pullOf(
+    transform: (A) -> Moment<B>,
+): Moment<Cell<B>> = Cell.pull(map(transform))
 
 fun <A, B> Cell<A>.divertEarlyOf(
     transform: (A) -> EventStream<B>,

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/cellUtils.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/cellUtils.kt
@@ -2,6 +2,49 @@ package io.github.oxidefrp.core.shared
 
 import io.github.oxidefrp.core.Cell
 import io.github.oxidefrp.core.EventStream
+import io.github.oxidefrp.core.Moment
+import io.github.oxidefrp.core.Signal
+import io.github.oxidefrp.core.hold
+import io.github.oxidefrp.core.pullOf
+
+fun <A> Cell.Companion.pull(
+    cell: Cell<Moment<A>>,
+): Moment<Cell<A>> = cell.sample().pullOf { initialMoment ->
+    initialMoment.pullOf { initialValue ->
+        EventStream.pull(cell.newValues).hold(initialValue)
+    }
+}
+
+fun <S, A> Cell.Companion.enter(
+    cell: Cell<State<S, A>>,
+): StateStructure<S, Cell<A>> = Moment.enter(cell.sample()).constructOf { initialValue ->
+    EventStream.enter(cell.newValues).pullOf { newValues ->
+        newValues.hold(initialValue)
+    }
+}
+
+fun <S, A> Cell.Companion.pullEnter(
+    cell: Cell<MomentState<S, A>>,
+): StateStructure<S, Cell<A>> = Moment.pullEnter(cell.sample()).constructOf { initialValue ->
+    EventStream.pullEnter(cell.newValues).pullOf { newValues ->
+        newValues.hold(initialValue)
+    }
+}
+
+fun <S, A> Cell.Companion.construct(
+    cell: Cell<StateStructure<S, A>>,
+): StateStructure<S, Cell<A>> = object : StateStructure<S, Cell<A>>() {
+    override fun constructDirectly(
+        stateSignal: Signal<S>,
+    ): MomentState<StateSchedulerLayer<S>, Cell<A>> = MomentState.enterDirectly { inputLayer ->
+        cell.pullOf { structure ->
+            structure.constructDirectly(stateSignal = stateSignal).enterDirectly(inputLayer)
+        }.map(Cell.Companion::unzip2).map { (layerCell, valueCell) ->
+            val outputLayer = StateSchedulerLayer.divert(layerCell)
+            return@map Pair(outputLayer, valueCell)
+        }
+    }
+}
 
 fun <A, B> Cell.Companion.unzip2(
     cell: Cell<Pair<A, B>>,

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/momentUtils.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/momentUtils.kt
@@ -1,0 +1,25 @@
+package io.github.oxidefrp.core.shared
+
+import io.github.oxidefrp.core.Moment
+
+fun <S, A> Moment.Companion.enter(moment: Moment<State<S, A>>): MomentState<S, A> =
+    object : MomentState<S, A>() {
+        override fun enterDirectly(oldState: S): Moment<Pair<S, A>> =
+            moment.map { innerState ->
+                innerState.enterDirectly(oldState)
+            }
+    }
+
+fun <S, A> Moment.Companion.pullEnter(moment: Moment<MomentState<S, A>>): MomentState<S, A> =
+    object : MomentState<S, A>() {
+        override fun enterDirectly(oldState: S): Moment<Pair<S, A>> =
+            moment.pullOf { innerMoment ->
+                innerMoment.enterDirectly(oldState)
+            }
+    }
+
+fun <A, B> Moment<A>.pullOf(transform: (A) -> Moment<B>): Moment<B> =
+    Moment.pull(map(transform))
+
+fun <S, A, B> Moment<A>.enterOf(transform: (A) -> State<S, B>): MomentState<S, B> =
+    Moment.enter(map(transform))

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/streamUtils.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/streamUtils.kt
@@ -33,3 +33,7 @@ fun <A, B> EventStream.Companion.unzip2(
 fun <A> EventStream<A>.orElse(
     other: EventStream<A>,
 ): EventStream<A> = mergeWith(other) { l, _ -> l }
+
+fun <S, A> EventStream.Companion.enter(
+    stream: EventStream<State<S, A>>,
+): StateScheduler<S, EventStream<A>> = pullEnter(stream.map { it.asMomentState() })

--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/streamUtils.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/streamUtils.kt
@@ -1,7 +1,27 @@
 package io.github.oxidefrp.core.shared
 
 import io.github.oxidefrp.core.EventStream
+import io.github.oxidefrp.core.Signal
 import io.github.oxidefrp.core.mergeWith
+
+fun <S, A> EventStream.Companion.pullEnter(
+    stream: EventStream<MomentState<S, A>>,
+): StateScheduler<S, EventStream<A>> = object : StateScheduler<S, EventStream<A>>() {
+    override fun scheduleDirectly(
+        stateSignal: Signal<S>,
+    ) = object : State<StateSchedulerLayer<S>, EventStream<A>>() {
+        override fun enterDirectly(
+            oldState: StateSchedulerLayer<S>,
+        ): Pair<StateSchedulerLayer<S>, EventStream<A>> {
+            val previousSchedulerLayer = oldState
+
+            return previousSchedulerLayer.squashWith(
+                stateSignal = stateSignal,
+                stream = stream
+            )
+        }
+    }
+}
 
 fun <A, B> EventStream.Companion.unzip2(
     stream: EventStream<Pair<A, B>>,

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/CellOperatorsOperationalUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/CellOperatorsOperationalUnitTests.kt
@@ -1,6 +1,7 @@
 package io.github.oxidefrp.core
 
 import io.github.oxidefrp.core.shared.StateSchedulerLayer
+import io.github.oxidefrp.core.shared.pullEnter
 import io.github.oxidefrp.core.test_utils.tableSignal
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/EventStreamOperatorsOperationalTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/EventStreamOperatorsOperationalTests.kt
@@ -1,5 +1,6 @@
 package io.github.oxidefrp.core
 
+import io.github.oxidefrp.core.shared.pullOf
 import io.github.oxidefrp.core.test_utils.generateOccurrencesSequence
 import kotlin.math.sin
 import kotlin.test.Test

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/OperatorsOperationalIntegrationTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/OperatorsOperationalIntegrationTests.kt
@@ -1,5 +1,6 @@
 package io.github.oxidefrp.core
 
+import io.github.oxidefrp.core.shared.pullOf
 import io.github.oxidefrp.core.test_utils.generateIntegerEventStream
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateSchedulerSharedUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateSchedulerSharedUnitTests.kt
@@ -2,6 +2,7 @@ package io.github.oxidefrp.core
 
 import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.StateSchedulerLayer
+import io.github.oxidefrp.core.shared.pullEnter
 import io.github.oxidefrp.core.test_framework.shared.EventOccurrenceDesc
 import io.github.oxidefrp.core.test_framework.shared.EventStreamSpec
 import io.github.oxidefrp.core.test_framework.shared.TestCheck

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateSchedulerSharedUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateSchedulerSharedUnitTests.kt
@@ -1,5 +1,6 @@
 package io.github.oxidefrp.core
 
+import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.StateSchedulerLayer
 import io.github.oxidefrp.core.test_framework.shared.EventOccurrenceDesc
 import io.github.oxidefrp.core.test_framework.shared.EventStreamSpec
@@ -11,8 +12,20 @@ import kotlin.test.Test
 
 class StateSchedulerSharedUnitTests {
     object EventStreamPullEnter {
+        private data class S(
+            val sum: Int,
+        )
+
         @Test
         fun test() = testSystem {
+            fun momentState(n: Int) = object : MomentState<S, String>() {
+                override fun enterDirectly(oldState: S): Moment<Pair<S, String>> = getCurrentTick().map {
+                    val result = "${oldState.sum}@${it.t}.0/$n"
+                    val newState = S(sum = oldState.sum + n)
+                    Pair(newState, result)
+                }
+            }
+
             val stateSignal = buildInputSignal {
                 when (it) {
                     Tick(t = 20) -> S(sum = 20)

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateStructureDenotationalUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateStructureDenotationalUnitTests.kt
@@ -4,6 +4,7 @@ import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.State
 import io.github.oxidefrp.core.shared.StateSchedulerLayer
 import io.github.oxidefrp.core.shared.StateStructure
+import io.github.oxidefrp.core.shared.construct
 import io.github.oxidefrp.core.shared.orElse
 import io.github.oxidefrp.core.test_utils.tableSignal
 import kotlin.test.Test

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateStructureSharedUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/StateStructureSharedUnitTests.kt
@@ -3,6 +3,7 @@ package io.github.oxidefrp.core
 import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.StateSchedulerLayer
 import io.github.oxidefrp.core.shared.StateStructure
+import io.github.oxidefrp.core.shared.construct
 import io.github.oxidefrp.core.shared.orElse
 import io.github.oxidefrp.core.test_framework.shared.CellSpec
 import io.github.oxidefrp.core.test_framework.shared.CellValueDesc

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/TestContext.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/TestContext.kt
@@ -13,6 +13,7 @@ import io.github.oxidefrp.core.test_framework.shared.InputCellSpec
 import io.github.oxidefrp.core.test_framework.shared.InputSignalSpec
 import io.github.oxidefrp.core.test_framework.shared.InputStreamSpec
 import io.github.oxidefrp.core.test_framework.shared.Tick
+import java.lang.IllegalStateException
 
 internal class TestContext(
     private val tickStream: EventStream<Tick>,
@@ -65,4 +66,9 @@ internal class TestContext(
     ): Signal<A> = buildInputSignal(
         spec = InputSignalSpec(provideValue = provideValue)
     )
+
+    fun getCurrentTick() = tickStream.currentOccurrence.map {
+        val occurrence = it ?: throw IllegalStateException("No current tick")
+        occurrence.event
+    }
 }

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/shared/StateSchedulerSharedUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/shared/StateSchedulerSharedUnitTests.kt
@@ -1,13 +1,10 @@
-package io.github.oxidefrp.core
+package io.github.oxidefrp.core.test_framework.shared
 
+import io.github.oxidefrp.core.EventStream
+import io.github.oxidefrp.core.Moment
 import io.github.oxidefrp.core.shared.MomentState
 import io.github.oxidefrp.core.shared.StateSchedulerLayer
 import io.github.oxidefrp.core.shared.pullEnter
-import io.github.oxidefrp.core.test_framework.shared.EventOccurrenceDesc
-import io.github.oxidefrp.core.test_framework.shared.EventStreamSpec
-import io.github.oxidefrp.core.test_framework.shared.TestCheck
-import io.github.oxidefrp.core.test_framework.shared.TestSpec
-import io.github.oxidefrp.core.test_framework.shared.Tick
 import io.github.oxidefrp.core.test_framework.testSystem
 import kotlin.test.Test
 

--- a/denotational/examples/widget-examples/src/main/kotlin/main.kt
+++ b/denotational/examples/widget-examples/src/main/kotlin/main.kt
@@ -4,7 +4,7 @@ import io.github.oxidefrp.core.EventStream
 import io.github.oxidefrp.core.Moment
 import io.github.oxidefrp.core.Time
 import io.github.oxidefrp.core.hold
-import io.github.oxidefrp.core.pullOf
+import io.github.oxidefrp.core.shared.pullOf
 
 fun main() {
     val prompts = EventStream.ofOccurrences(

--- a/operational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/TestContext.kt
+++ b/operational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/TestContext.kt
@@ -2,16 +2,21 @@ package io.github.oxidefrp.core.test_framework
 
 import io.github.oxidefrp.core.Cell
 import io.github.oxidefrp.core.EventStream
+import io.github.oxidefrp.core.Signal
 import io.github.oxidefrp.core.impl.event_stream.CellVertex
 import io.github.oxidefrp.core.impl.event_stream.EventStreamVertex
+import io.github.oxidefrp.core.impl.signal.SignalVertex
 import io.github.oxidefrp.core.test_framework.input.InputCellVertex
 import io.github.oxidefrp.core.test_framework.input.InputEventStreamVertex
+import io.github.oxidefrp.core.test_framework.input.InputSignalVertex
 import io.github.oxidefrp.core.test_framework.shared.CellValueSpec
 import io.github.oxidefrp.core.test_framework.shared.EventOccurrenceDesc
 import io.github.oxidefrp.core.test_framework.shared.FiniteInputCellSpec
 import io.github.oxidefrp.core.test_framework.shared.FiniteInputStreamSpec
 import io.github.oxidefrp.core.test_framework.shared.InputCellSpec
+import io.github.oxidefrp.core.test_framework.shared.InputSignalSpec
 import io.github.oxidefrp.core.test_framework.shared.InputStreamSpec
+import io.github.oxidefrp.core.test_framework.shared.Tick
 
 internal class TestContext(
     private val tickStream: TickStream,
@@ -50,5 +55,20 @@ internal class TestContext(
             initialValue = initialValue,
             innerValues = innerValues,
         ),
+    )
+
+    fun <A> buildInputSignal(
+        spec: InputSignalSpec<A>,
+    ): Signal<A> = object : Signal<A>() {
+        override val vertex: SignalVertex<A> = InputSignalVertex(
+            tickStream = tickStream,
+            spec = spec,
+        )
+    }
+
+    fun <A> buildInputSignal(
+        provideValue: (tick: Tick) -> A,
+    ): Signal<A> = buildInputSignal(
+        spec = InputSignalSpec(provideValue = provideValue)
     )
 }

--- a/operational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/TestContext.kt
+++ b/operational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/TestContext.kt
@@ -71,4 +71,9 @@ internal class TestContext(
     ): Signal<A> = buildInputSignal(
         spec = InputSignalSpec(provideValue = provideValue)
     )
+
+    fun getCurrentTick() = tickStream.currentOccurrence.map {
+        val occurrence = it ?: throw IllegalStateException("No current tick")
+        occurrence.event
+    }
 }

--- a/operational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/input/InputSignalVertex.kt
+++ b/operational/core/src/test/kotlin/io/github/oxidefrp/core/test_framework/input/InputSignalVertex.kt
@@ -1,0 +1,14 @@
+package io.github.oxidefrp.core.test_framework.input
+
+import io.github.oxidefrp.core.impl.Transaction
+import io.github.oxidefrp.core.impl.signal.SignalVertex
+import io.github.oxidefrp.core.test_framework.TickStream
+import io.github.oxidefrp.core.test_framework.shared.InputSignalSpec
+
+internal class InputSignalVertex<A>(
+    private val tickStream: TickStream,
+    private val spec: InputSignalSpec<A>,
+) : SignalVertex<A>() {
+    override fun pullCurrentValue(transaction: Transaction): A =
+        spec.getValue(tick = tickStream.currentTick)
+}


### PR DESCRIPTION
- Implement operational `buildInputSignal`
- Use a `Time`-independent variant of `momentState` util
- Make some `StateScheduler` utils shared
- Share more basic utils
- Actually share `StateSchedulerSharedUnitTests`
