### PR TITLE
constructEnterDirectly 1

### DIFF
--- a/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/StateStructure.kt
+++ b/denotational/core/src/main/kotlin/io/github/oxidefrp/core/shared/StateStructure.kt
@@ -34,6 +34,12 @@ abstract class StateStructure<S, out A> {
         stateSignal: Signal<S>,
     ): MomentState<StateSchedulerLayer<S>, A>
 
+    fun constructEnterDirectly(
+        stateSignal: Signal<S>,
+        inputLayer: StateSchedulerLayer<S>,
+    ): Moment<Pair<StateSchedulerLayer<S>, A>> =
+        constructDirectly(stateSignal = stateSignal).enterDirectly(oldState = inputLayer)
+
     fun seed(initState: S): Moment<Pair<Cell<S>, A>> =
         EventStream.pullLooped1 { newStatesLoop: EventStream<S> ->
             val firstLayer = StateSchedulerLayer<S>(EventStream.never())

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/MomentStateDenotationalUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/MomentStateDenotationalUnitTests.kt
@@ -5,7 +5,7 @@ import io.github.oxidefrp.core.test_utils.tableSignal
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class MomentStateUnitTests {
+class MomentStateDenotationalUnitTests {
     object AsStateStructure {
         private val stateSignal = tableSignal(
             table = mapOf(


### PR DESCRIPTION
- Implement `constructEnterDirectly` util
- Rename `MomentStateUnitTests` to `MomentStateDenotationalUnitTests`
