### PR TITLE
port StateScheduler tests 1

### DIFF
--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/shared/MomentStateSharedUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/shared/MomentStateSharedUnitTests.kt
@@ -73,7 +73,7 @@ class MomentStateSharedUnitTests {
                                         EventOccurrenceDesc(tick = Tick(t = 25), event = S(sum = 25)),
                                         EventOccurrenceDesc(tick = Tick(t = 40), event = S(sum = 40)),
                                         EventOccurrenceDesc(tick = Tick(t = 50), event = S(sum = 50)),
-                                    )
+                                    ),
                                 ),
                             ),
                         ),

--- a/denotational/core/src/test/kotlin/io/github/oxidefrp/core/shared/StateSchedulerSharedUnitTests.kt
+++ b/denotational/core/src/test/kotlin/io/github/oxidefrp/core/shared/StateSchedulerSharedUnitTests.kt
@@ -1,10 +1,12 @@
-package io.github.oxidefrp.core.test_framework.shared
+package io.github.oxidefrp.core.shared
 
 import io.github.oxidefrp.core.EventStream
 import io.github.oxidefrp.core.Moment
-import io.github.oxidefrp.core.shared.MomentState
-import io.github.oxidefrp.core.shared.StateSchedulerLayer
-import io.github.oxidefrp.core.shared.pullEnter
+import io.github.oxidefrp.core.test_framework.shared.EventOccurrenceDesc
+import io.github.oxidefrp.core.test_framework.shared.EventStreamSpec
+import io.github.oxidefrp.core.test_framework.shared.TestCheck
+import io.github.oxidefrp.core.test_framework.shared.TestSpec
+import io.github.oxidefrp.core.test_framework.shared.Tick
 import io.github.oxidefrp.core.test_framework.testSystem
 import kotlin.test.Test
 


### PR DESCRIPTION
- Fully port the `testFromStateSignal`test to the test framework
- Move `StateSchedulerSharedUnitTests` to the right package
